### PR TITLE
feat!: pint units support

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,24 +28,27 @@ pytest
 The following example demonstrates how to run a basic simulation using the mock simulator provided in the package.
 
 ```python
-from qruise.pasquans_interface import simulate, MockProvider
+from qruise.pasquans_interface import simulate, MockProvider, Q_
+import numpy as np
 
 result = simulate(
-    lattice_sites=[(0.0, 0.0), (1.0, 1.0)],
-    global_rabi_frequency=[1.0, 1.0],
-    global_phase=[0.0, 0.0],
-    global_detuning=[0.0, 0.0],
-    local_detuning=[0.0, 0.0],
+    lattice_sites=np.array([(0.0, 0.0), (1.0, 1.0)]) * Q_("micrometer"),
+    global_rabi_frequency=np.array([1.0, 1.0]) * Q_("MHz"),
+    global_phase=np.array([0.0, 0.0]) * Q_("rad"),
+    global_detuning=np.array([0.0, 0.0]) * Q_("MHz"),
+    local_detuning=np.array([0.0, 0.0]) * Q_("MHz"),
     init_state=[1.0, 0.0],
-    timegrid=[0.0, 1.0],
-    backend="mock_simulator",
+    timegrid=np.array([0.0, 1.0]) * Q_("microsecond"),
+    backend="mock_simulator_v2",
     backend_options={},
     provider=MockProvider(),
 )
 
+assert "error" not in result
+
 # Accessing the simulation results
 populations = result["state_populations"]
-assert "error" not in result
+
 print("Simulation Results:", populations)
 ```
 
@@ -54,7 +57,7 @@ print("Simulation Results:", populations)
 ## How to use the Interface
 The `qruise-pasquans-interface` package provides a simple API for simulating quantum operations. To use the interface, follow these steps:
 - **Import the `simulate` function**: Import the `simulate` function from the package to run quantum simulations.
-- **Define the simulation parameters**: Define the parameters for the quantum simulation, such as lattice sites, Rabi frequencies, phases, detunings, initial states, and time grid.
+- **Define the simulation parameters**: Use Q_ and numpy array to define parameters such as lattice sites, Rabi frequencies, phases, detunings, initial states, and the time grid.
 - **Select the provider**: Choose the provider that manages the backend simulators, such as the mock provider or a custom provider.
 - **Select the backend simulator**: Choose the backend simulator to use for the simulation, such as the mock simulator or a custom simulator.
 - **Run the simulation**: Call the `simulate` function with the specified parameters to run the quantum simulation.
@@ -69,7 +72,8 @@ A simulator in the qruise-pasquans-interface must inherit from the SimulatorBack
 **Step-by-step**:
 ```python
 from qruise.pasquans_interface import SimulatorBackend
-from typing import List, Tuple
+from qruise.pasquans_interface import ureg
+from pint import Quantity
 
 class CustomSimulator(SimulatorBackend):
     """Custom simulator backend"""
@@ -88,43 +92,78 @@ class CustomSimulator(SimulatorBackend):
         self.backend_options = backend_options
 
     def simulate(
-        self,
-        lattice_sites: List[Tuple[float, float]],
-        global_rabi_frequency: List[float],
-        global_phase: List[float],
-        global_detuning: List[float],
-        local_detuning: List[float],
-        timegrid: List[float],
-        init_state: List[float] = None,
-        backend_options: dict = None,
-    ) -> dict:
+            self,
+            lattice_sites: Quantity,
+            global_rabi_frequency: Quantity,
+            global_phase: Quantity,
+            global_detuning: Quantity,
+            local_detuning: Quantity,
+            init_state: list,
+            timegrid: Quantity,
+            backend_options={},
+        ) -> dict:
         """
-        Run a simulation on the custom backend.
+        Simulate the system.
+
+        This method simulates the dynamics of a quantum system based on input parameters
+        such as lattice configuration, Rabi frequencies, phases, and detuning values. It
+        returns a dictionary containing the simulation results and backend options used.
 
         Parameters
         ----------
-        lattice_sites : list[Tuple[float, float]]
-            List of positions of atoms in the lattice.
-        global_rabi_frequency : list[float]
-            Time-dependent global Rabi frequencies.
-        global_phase : list[float]
-            Time-dependent global phase values.
-        global_detuning : list[float]
-            Time-dependent global detuning values.
-        local_detuning : list[float]
-            Local detuning values for each lattice site.
-        timegrid : list[float]
-            Timeline for the simulation.
-        init_state : list[float], optional
-            Initial state of the quantum system, default is None.
+        lattice_sites : Quantity
+            A Pint Quantity representing the positions of atoms in the lattice. Expected to have
+            a unit of [length].
+        global_rabi_frequency : Quantity
+            A Pint Quantity representing the time-dependent global Rabi frequencies. Expected
+            to have a unit of [frequency].
+        global_phase : Quantity
+            A Pint Quantity representing the time-dependent global phases. Expected to have
+            a unit of [angle].
+        global_detuning : Quantity
+            A Pint Quantity representing the time-dependent global detuning values. Expected
+            to have a unit of [frequency].
+        local_detuning : Quantity
+            A Pint Quantity representing the local detuning values for each lattice site. Expected
+            to have a unit of [frequency].
+        init_state : list
+            A list representing the initial state of the system. Each element corresponds to the
+            state of a lattice site.
+        timegrid : Quantity
+            A Pint Quantity representing the time grid over which the simulation is run. Expected
+            to have a unit of [time].
         backend_options : dict, optional
-            Additional backend-specific configuration options.
+            A dictionary containing options specific to the simulation backend. Default is an
+            empty dictionary.
 
         Returns
         -------
         dict
-            Dictionary containing the results of the simulation, such as state populations and metadata.
+            A dictionary containing the following keys:
+            - "populations": List of state populations over time.
+            - "backend_options": The backend options used in the simulation.
         """
+                # Check if the lattice sites are in a distance unit
+        assert lattice_sites.dimensionality == ureg.meter.dimensionality
+        # Check if the global rabi frequency is in a frequency unit
+        assert global_rabi_frequency.dimensionality == ureg.hertz.dimensionality
+        # Check if the global phase is dimensionless
+        assert global_phase.dimensionless
+        # Check if the global detuning is in a frequency unit
+        assert global_detuning.dimensionality == ureg.hertz.dimensionality
+        # Check if the local detuning is in a frequency unit
+        assert local_detuning.dimensionality == ureg.hertz.dimensionality
+        # Check if the timegrid is in a time unit
+        assert timegrid.dimensionality == ureg.second.dimensionality
+
+        # Convert any units if your simulator requires it
+        lattice_sites = lattice_sites.to(ureg.meter)
+        global_rabi_frequency = global_rabi_frequency.to(ureg.hertz)
+        global_phase = global_phase.to(ureg.dimensionless)
+        global_detuning = global_detuning.to(ureg.hertz)
+        local_detuning = local_detuning.to(ureg.hertz)
+        timegrid = timegrid.to(ureg.second)
+
         # Example of running the simulation with mock data
         state_populations = [0.7, 0.3]  # Mock result for demonstration
         return {
@@ -148,7 +187,10 @@ class CustomSimulator(SimulatorBackend):
 ```
 Explanation of CustomSimulator:
 - Initialization: The constructor method initializes the custom simulator with options provided in backend_options. You can add custom configuration options here as needed.
-- simulate: Implements the main simulation logic. For demonstration purposes, this function returns a mock result (state_populations) and includes backend options. In a real implementation, you would add logic to perform the actual quantum simulation based on the provided parameters.
+- simulate: The simulate method implements the main logic for running a quantum simulation. It takes in various parameters, such as lattice sites, Rabi frequencies, and detunings, as Pint Quantity objects with associated units. You can:
+ - Validate: Check if the provided parameters have the correct dimensionality (e.g., [length] for lattice sites, [frequency] for Rabi frequencies).
+ - Convert: Convert the parameters to the units expected by the simulator backend if they differ (e.g., converting micrometers to meters or MHz to Hz).
+ - Simulate: Perform the actual simulation logic. In this example, the method returns a mock result (state_populations) for demonstration. In a real implementation, this is where the quantum system's behavior would be computed based on the inputs and any backend-specific constraints.
 - get_backend_information: Returns metadata about the backend, which can be useful for debugging and configuration checks.
 
 ### Custom Provider
@@ -183,15 +225,15 @@ from qruise.pasquans_interface import simulate
 
 # Example usage with the CustomProvider and CustomSimulator
 result = simulate(
-    lattice_sites=[(0.0, 0.0), (1.0, 1.0)],
-    global_rabi_frequency=[1.0, 1.0],
-    global_phase=[0.0, 0.0],
-    global_detuning=[0.0, 0.0],
-    local_detuning=[0.0, 0.0],
-    init_state=[1.0, 0.0],
-    timegrid=[0.0, 1.0],
+    lattice_sites=np.array([(0.0, 0.0, 0.0), (1.0, 1.0, 1.0)]) * Q_("micrometer"),
+    global_rabi_frequency=np.array([1.0, 1.0]) * Q_("MHz"),
+    global_phase=np.array([0.0, 0.0]) * Q_("rad"),
+    global_detuning=np.array([0.0, 0.0]) * Q_("MHz"),
+    local_detuning=np.array([0.0, 0.0]) * Q_("MHz"),
+    init_state=[0.0, 0.0],
+    timegrid=[0.0, 1.0] * Q_("microsecond"),
     backend="custom_simulator",
-    backend_options={"custom_parameter": 2.0},
+    backend_options={},
     provider=CustomProvider(),
 )
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,6 @@ To create a custom provider and simulator in the qruise-pasquans-interface, youâ
 ### Custom Simulator Backend
 A simulator in the qruise-pasquans-interface must inherit from the SimulatorBackend abstract base class and implement the required methods, such as simulate and get_backend_information.
 
-**Step-by-step**:
 ```python
 from qruise.pasquans_interface import SimulatorBackend
 from qruise.pasquans_interface import ureg
@@ -143,7 +142,7 @@ class CustomSimulator(SimulatorBackend):
             - "populations": List of state populations over time.
             - "backend_options": The backend options used in the simulation.
         """
-                # Check if the lattice sites are in a distance unit
+        # Check if the lattice sites are in a distance unit
         assert lattice_sites.dimensionality == ureg.meter.dimensionality
         # Check if the global rabi frequency is in a frequency unit
         assert global_rabi_frequency.dimensionality == ureg.hertz.dimensionality
@@ -188,15 +187,14 @@ class CustomSimulator(SimulatorBackend):
 Explanation of CustomSimulator:
 - Initialization: The constructor method initializes the custom simulator with options provided in backend_options. You can add custom configuration options here as needed.
 - simulate: The simulate method implements the main logic for running a quantum simulation. It takes in various parameters, such as lattice sites, Rabi frequencies, and detunings, as Pint Quantity objects with associated units. You can:
- - Validate: Check if the provided parameters have the correct dimensionality (e.g., [length] for lattice sites, [frequency] for Rabi frequencies).
- - Convert: Convert the parameters to the units expected by the simulator backend if they differ (e.g., converting micrometers to meters or MHz to Hz).
- - Simulate: Perform the actual simulation logic. In this example, the method returns a mock result (state_populations) for demonstration. In a real implementation, this is where the quantum system's behavior would be computed based on the inputs and any backend-specific constraints.
+  - Validate: Check if the provided parameters have the correct dimensionality (e.g., [length] for lattice sites, [frequency] for Rabi frequencies).
+  - Convert: Convert the parameters to the units expected by the simulator backend if they differ (e.g., converting micrometers to meters or MHz to Hz).
+  - Simulate: Perform the actual simulation logic. In this example, the method returns a mock result (state_populations) for demonstration. In a real implementation, this is where the quantum system's behavior would be computed based on the inputs and any backend-specific constraints.
 - get_backend_information: Returns metadata about the backend, which can be useful for debugging and configuration checks.
 
 ### Custom Provider
 A provider in the qruise-pasquans-interface must inherit from the PasquansProvider abstract base class and implement the _get_simulators method, which returns a list of available simulator classes.
 
-**Step-by-step**:
 ```python
 from qruise.pasquans_interface import PasquansProvider
 from typing import List

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,6 +49,8 @@ package_dir =
 # For more information, check out https://semver.org/.
 install_requires =
     importlib-metadata; python_version<"3.8"
+    pint
+    numpy>1.24
 
 
 [options.packages.find]

--- a/src/qruise/pasquans_interface/__init__.py
+++ b/src/qruise/pasquans_interface/__init__.py
@@ -5,6 +5,7 @@ from qruise.pasquans_interface.mock_provider import MockProvider
 from qruise.pasquans_interface.provider import PasquansProvider
 from qruise.pasquans_interface.simulator_backend import SimulatorBackend
 from qruise.pasquans_interface.simulate import simulate
+import pint
 
 __all__ = [
     "MockSimulator",
@@ -13,6 +14,9 @@ __all__ = [
     "SimulatorBackend",
     "simulate",
 ]
+
+ureg = pint.UnitRegistry()
+Q_ = ureg.Quantity
 
 if sys.version_info[:2] >= (3, 8):
     # TODO: Import directly (no need for conditional) when `python_requires = >= 3.8`

--- a/src/qruise/pasquans_interface/__init__.py
+++ b/src/qruise/pasquans_interface/__init__.py
@@ -1,22 +1,24 @@
 import sys
 
-from qruise.pasquans_interface.mock_simulator import MockSimulator
+from qruise.pasquans_interface.mock_simulator import MockSimulator, MockSimulatorV2
 from qruise.pasquans_interface.mock_provider import MockProvider
 from qruise.pasquans_interface.provider import PasquansProvider
 from qruise.pasquans_interface.simulator_backend import SimulatorBackend
 from qruise.pasquans_interface.simulate import simulate
-import pint
+from qruise.pasquans_interface.units import ureg, Q_
+
 
 __all__ = [
     "MockSimulator",
+    "MockSimulatorV2",
     "MockProvider",
     "PasquansProvider",
     "SimulatorBackend",
     "simulate",
+    "ureg",
+    "Q_",
 ]
 
-ureg = pint.UnitRegistry()
-Q_ = ureg.Quantity
 
 if sys.version_info[:2] >= (3, 8):
     # TODO: Import directly (no need for conditional) when `python_requires = >= 3.8`

--- a/src/qruise/pasquans_interface/mock_provider.py
+++ b/src/qruise/pasquans_interface/mock_provider.py
@@ -1,5 +1,5 @@
 from qruise.pasquans_interface.provider import PasquansProvider
-from qruise.pasquans_interface.mock_simulator import MockSimulator
+from qruise.pasquans_interface.mock_simulator import MockSimulator, MockSimulatorV2
 from qruise.pasquans_interface.simulator_backend import SimulatorBackend
 
 
@@ -25,4 +25,4 @@ class MockProvider(PasquansProvider):
         list[SimulatorBackend]
             A list of available simulators, in this case, containing only the MockSimulator class.
         """
-        return [MockSimulator]
+        return [MockSimulator, MockSimulatorV2]

--- a/src/qruise/pasquans_interface/mock_simulator.py
+++ b/src/qruise/pasquans_interface/mock_simulator.py
@@ -1,5 +1,6 @@
 from .simulator_backend import SimulatorBackend
 from .units import ureg
+from pint import Quantity
 
 
 class MockSimulator(SimulatorBackend):
@@ -127,47 +128,55 @@ class MockSimulatorV2(SimulatorBackend):
 
     def simulate(
         self,
-        lattice_sites,
-        global_rabi_frequency,
-        global_phase,
-        global_detuning,
-        local_detuning,
-        init_state=None,
-        timegrid=None,
+        lattice_sites: Quantity,
+        global_rabi_frequency: Quantity,
+        global_phase: Quantity,
+        global_detuning: Quantity,
+        local_detuning: Quantity,
+        init_state: list,
+        timegrid: Quantity,
         backend_options={},
     ) -> dict:
         """
         Simulate the system.
 
-        This method mimics the simulation process of a quantum system. It takes various
-        inputs representing system parameters (such as lattice sites, rabi frequency,
-        and detuning values) and returns mock simulation results. The results include
-        state populations and the backend options used for the simulation.
+        This method simulates the dynamics of a quantum system based on input parameters
+        such as lattice configuration, Rabi frequencies, phases, and detuning values. It
+        returns a dictionary containing the simulation results and backend options used.
 
         Parameters
         ----------
-        lattice_sites : list
-            A list of tuples representing the positions of atoms in the lattice.
-        global_rabi_frequency : list
-            A list of time-dependent global rabi frequencies.
-        global_phase : list
-            A list of time-dependent global phase values.
-        global_detuning : list
-            A list of time-dependent global detuning values.
-        local_detuning : list
-            A list of local detuning values for each lattice site.
-        init_state : list, optional
-            An optional list representing the initial state of the system. Default is None.
-        timegrid : list, optional
-            An optional list representing the time grid over which the simulation is run. Default is None.
+        lattice_sites : Quantity
+            A Pint Quantity representing the positions of atoms in the lattice. Expected to have
+            a unit of [length].
+        global_rabi_frequency : Quantity
+            A Pint Quantity representing the time-dependent global Rabi frequencies. Expected
+            to have a unit of [frequency].
+        global_phase : Quantity
+            A Pint Quantity representing the time-dependent global phases. Expected to have
+            a unit of [angle].
+        global_detuning : Quantity
+            A Pint Quantity representing the time-dependent global detuning values. Expected
+            to have a unit of [frequency].
+        local_detuning : Quantity
+            A Pint Quantity representing the local detuning values for each lattice site. Expected
+            to have a unit of [frequency].
+        init_state : list
+            A list representing the initial state of the system. Each element corresponds to the
+            state of a lattice site.
+        timegrid : Quantity
+            A Pint Quantity representing the time grid over which the simulation is run. Expected
+            to have a unit of [time].
         backend_options : dict, optional
-            A dictionary of options specific to the backend for this simulation.
+            A dictionary containing options specific to the simulation backend. Default is an
+            empty dictionary.
 
         Returns
         -------
         dict
-            A dictionary containing the simulation results, including state populations
-            and the backend options used in the simulation.
+            A dictionary containing the following keys:
+            - "populations": List of state populations over time.
+            - "backend_options": The backend options used in the simulation.
         """
         # Check if the lattice sites are in a distance unit
         assert lattice_sites.dimensionality == ureg.meter.dimensionality
@@ -179,6 +188,16 @@ class MockSimulatorV2(SimulatorBackend):
         assert global_detuning.dimensionality == ureg.hertz.dimensionality
         # Check if the local detuning is in a frequency unit
         assert local_detuning.dimensionality == ureg.hertz.dimensionality
+        # Check if the timegrid is in a time unit
+        assert timegrid.dimensionality == ureg.second.dimensionality
+
+        # Convert any units if your simulator requires it
+        lattice_sites = lattice_sites.to(ureg.meter)
+        global_rabi_frequency = global_rabi_frequency.to(ureg.hertz)
+        global_phase = global_phase.to(ureg.dimensionless)
+        global_detuning = global_detuning.to(ureg.hertz)
+        local_detuning = local_detuning.to(ureg.hertz)
+        timegrid = timegrid.to(ureg.second)
 
         return {
             "state_populations": [0.5, 0.5],  # Mocked simulation result

--- a/src/qruise/pasquans_interface/mock_simulator.py
+++ b/src/qruise/pasquans_interface/mock_simulator.py
@@ -1,4 +1,5 @@
 from .simulator_backend import SimulatorBackend
+from .units import ureg
 
 
 class MockSimulator(SimulatorBackend):
@@ -73,6 +74,112 @@ class MockSimulator(SimulatorBackend):
             A dictionary containing the simulation results, including state populations
             and the backend options used in the simulation.
         """
+        return {
+            "state_populations": [0.5, 0.5],  # Mocked simulation result
+            "backend_options": backend_options,
+        }
+
+    def get_backend_information(self) -> dict:
+        """
+        Get information about the backend.
+
+        This method provides metadata about the mock backend, including the backend's name
+        and the options it was initialized with.
+
+        Returns
+        -------
+        dict
+            A dictionary containing the name of the backend and its configuration options.
+        """
+        return {
+            "name": self.name,
+            "backend_options": self._backend_options,
+        }
+
+
+class MockSimulatorV2(SimulatorBackend):
+    """
+    A concrete implementation of the SimulatorBackend class for mock simulations.
+
+    This class simulates a quantum backend for testing purposes. It mimics the behavior of a
+    real backend, allowing developers to test their applications without needing an actual
+    quantum system. It stores backend options and provides basic simulation functionality
+    by returning mock results.
+    """
+
+    def __init__(self, provider, **backend_options):
+        """
+        Constructor for the MockSimulator class.
+
+        This method initializes the mock simulator by storing the provider and any additional
+        backend options. The backend is given the name 'mock_simulator' to indicate its role.
+
+        Parameters
+        ----------
+        provider : object
+            The provider responsible for managing this backend.
+        **backend_options : dict, optional
+            Additional keyword arguments used for configuring the backend.
+        """
+        self._backend_options = backend_options
+        self.provider = provider
+        self.name = "mock_simulator_v2"
+
+    def simulate(
+        self,
+        lattice_sites,
+        global_rabi_frequency,
+        global_phase,
+        global_detuning,
+        local_detuning,
+        init_state=None,
+        timegrid=None,
+        backend_options={},
+    ) -> dict:
+        """
+        Simulate the system.
+
+        This method mimics the simulation process of a quantum system. It takes various
+        inputs representing system parameters (such as lattice sites, rabi frequency,
+        and detuning values) and returns mock simulation results. The results include
+        state populations and the backend options used for the simulation.
+
+        Parameters
+        ----------
+        lattice_sites : list
+            A list of tuples representing the positions of atoms in the lattice.
+        global_rabi_frequency : list
+            A list of time-dependent global rabi frequencies.
+        global_phase : list
+            A list of time-dependent global phase values.
+        global_detuning : list
+            A list of time-dependent global detuning values.
+        local_detuning : list
+            A list of local detuning values for each lattice site.
+        init_state : list, optional
+            An optional list representing the initial state of the system. Default is None.
+        timegrid : list, optional
+            An optional list representing the time grid over which the simulation is run. Default is None.
+        backend_options : dict, optional
+            A dictionary of options specific to the backend for this simulation.
+
+        Returns
+        -------
+        dict
+            A dictionary containing the simulation results, including state populations
+            and the backend options used in the simulation.
+        """
+        # Check if the lattice sites are in a distance unit
+        assert lattice_sites.dimensionality == ureg.meter.dimensionality
+        # Check if the global rabi frequency is in a frequency unit
+        assert global_rabi_frequency.dimensionality == ureg.hertz.dimensionality
+        # Check if the global phase is dimensionless
+        assert global_phase.dimensionless
+        # Check if the global detuning is in a frequency unit
+        assert global_detuning.dimensionality == ureg.hertz.dimensionality
+        # Check if the local detuning is in a frequency unit
+        assert local_detuning.dimensionality == ureg.hertz.dimensionality
+
         return {
             "state_populations": [0.5, 0.5],  # Mocked simulation result
             "backend_options": backend_options,

--- a/src/qruise/pasquans_interface/units.py
+++ b/src/qruise/pasquans_interface/units.py
@@ -1,0 +1,4 @@
+import pint
+
+ureg = pint.UnitRegistry()
+Q_ = ureg.Quantity

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,3 +5,8 @@ from qruise.pasquans_interface import MockProvider
 @pytest.fixture
 def mock_simulator():
     return MockProvider().get_backend("mock_simulator")
+
+
+@pytest.fixture
+def mock_simulator_v2():
+    return MockProvider().get_backend("mock_simulator_v2")

--- a/tests/test_mock_simulator.py
+++ b/tests/test_mock_simulator.py
@@ -1,4 +1,4 @@
-from qruise.pasquans_interface import MockSimulator
+from qruise.pasquans_interface import MockSimulator, MockSimulatorV2
 
 
 def test_mock_simulator(mock_simulator):
@@ -10,3 +10,8 @@ def test_backend_information(mock_simulator):
     backend_info = mock_simulator.get_backend_information()
     assert backend_info["name"] == "mock_simulator"
     assert backend_info["backend_options"] == {}
+
+
+def test_mock_simulator_v2(mock_simulator_v2):
+    assert isinstance(mock_simulator_v2, MockSimulatorV2)
+    assert mock_simulator_v2.name == "mock_simulator_v2"

--- a/tests/test_pint_quantity.py
+++ b/tests/test_pint_quantity.py
@@ -1,6 +1,10 @@
 from qruise.pasquans_interface import ureg, Q_
 import numpy as np
 
+freqs = Q_(np.array([1, 2, 3]), "MHz")
+
+converted = freqs.to("rad/s")
+
 
 def test_ureg():
     assert ureg
@@ -12,12 +16,7 @@ def test_conversion_mhz_to_rad_per_s():
 
 
 def test_convert_array_mhz_to_rad_per_s():
-    freqs = Q_(np.array([1, 2, 3]), "MHz")
 
-    converted = freqs.to("rad/s")
-
-    # Compare magnitudes using np.testing.assert_allclose
     np.testing.assert_allclose(converted.magnitude, np.array([1e6, 2e6, 3e6]))
 
-    # Compare units
     assert converted.units == ureg.rad / ureg.s

--- a/tests/test_pint_quantity.py
+++ b/tests/test_pint_quantity.py
@@ -1,0 +1,23 @@
+from qruise.pasquans_interface import ureg, Q_
+import numpy as np
+
+
+def test_ureg():
+    assert ureg
+    assert Q_(1, "m") == 1 * ureg.meter
+
+
+def test_conversion_mhz_to_rad_per_s():
+    assert Q_(1, "MHz").to("rad/s") == 1e6 * ureg.rad / ureg.s
+
+
+def test_convert_array_mhz_to_rad_per_s():
+    freqs = Q_(np.array([1, 2, 3]), "MHz")
+
+    converted = freqs.to("rad/s")
+
+    # Compare magnitudes using np.testing.assert_allclose
+    np.testing.assert_allclose(converted.magnitude, np.array([1e6, 2e6, 3e6]))
+
+    # Compare units
+    assert converted.units == ureg.rad / ureg.s

--- a/tests/test_readme_code.py
+++ b/tests/test_readme_code.py
@@ -1,6 +1,8 @@
-from qruise.pasquans_interface import simulate, MockProvider
+from qruise.pasquans_interface import simulate, MockProvider, Q_, ureg
+import numpy as np
 from qruise.pasquans_interface import SimulatorBackend
 from qruise.pasquans_interface import PasquansProvider
+from pint import Quantity
 from typing import List, Tuple
 
 
@@ -22,6 +24,28 @@ def test_simulate_function_in_readme():
     populations = result["state_populations"]
     assert "error" not in result
     assert populations == [0.5, 0.5]
+
+
+def test_simulate_function_v2_in_readme():
+    result = simulate(
+        lattice_sites=np.array([(0.0, 0.0), (1.0, 1.0)]) * Q_("micrometer"),
+        global_rabi_frequency=np.array([1.0, 1.0]) * Q_("MHz"),
+        global_phase=np.array([0.0, 0.0]) * Q_("rad"),
+        global_detuning=np.array([0.0, 0.0]) * Q_("MHz"),
+        local_detuning=np.array([0.0, 0.0]) * Q_("MHz"),
+        init_state=[1.0, 0.0],
+        timegrid=np.array([0.0, 1.0]) * Q_("microsecond"),
+        backend="mock_simulator_v2",
+        backend_options={},
+        provider=MockProvider(),
+    )
+
+    assert "error" not in result
+
+    # Accessing the simulation results
+    populations = result["state_populations"]
+
+    print("Simulation Results:", populations)
 
 
 def test_custom_provider_and_simulator_in_readme():
@@ -133,3 +157,149 @@ def test_custom_provider_and_simulator_in_readme():
 
     # Access simulation results
     assert result["state_populations"] == [0.7, 0.3]
+
+
+def test_custom_provider_and_simulator_v2_in_readme():
+    class CustomSimulator(SimulatorBackend):
+        """Custom simulator backend"""
+
+        def __init__(self, **backend_options):
+            """
+            Initialize the CustomSimulator with specific backend options.
+
+            Parameters
+            ----------
+            backend_options : dict
+                Dictionary containing backend-specific configuration parameters.
+            """
+            self.name = "custom_simulator"
+            self.custom_parameter = backend_options.get(
+                "custom_parameter", 1.0
+            )  # Example parameter
+            self.backend_options = backend_options
+
+        def simulate(
+            self,
+            lattice_sites: Quantity,
+            global_rabi_frequency: Quantity,
+            global_phase: Quantity,
+            global_detuning: Quantity,
+            local_detuning: Quantity,
+            init_state: list,
+            timegrid: Quantity,
+            backend_options={},
+        ) -> dict:
+            """
+            Simulate the system.
+
+            This method simulates the dynamics of a quantum system based on input parameters
+            such as lattice configuration, Rabi frequencies, phases, and detuning values. It
+            returns a dictionary containing the simulation results and backend options used.
+
+            Parameters
+            ----------
+            lattice_sites : Quantity
+                A Pint Quantity representing the positions of atoms in the lattice. Expected to have
+                a unit of [length].
+            global_rabi_frequency : Quantity
+                A Pint Quantity representing the time-dependent global Rabi frequencies. Expected
+                to have a unit of [frequency].
+            global_phase : Quantity
+                A Pint Quantity representing the time-dependent global phases. Expected to have
+                a unit of [angle].
+            global_detuning : Quantity
+                A Pint Quantity representing the time-dependent global detuning values. Expected
+                to have a unit of [frequency].
+            local_detuning : Quantity
+                A Pint Quantity representing the local detuning values for each lattice site. Expected
+                to have a unit of [frequency].
+            init_state : list
+                A list representing the initial state of the system. Each element corresponds to the
+                state of a lattice site.
+            timegrid : Quantity
+                A Pint Quantity representing the time grid over which the simulation is run. Expected
+                to have a unit of [time].
+            backend_options : dict, optional
+                A dictionary containing options specific to the simulation backend. Default is an
+                empty dictionary.
+
+            Returns
+            -------
+            dict
+                A dictionary containing the following keys:
+                - "populations": List of state populations over time.
+                - "backend_options": The backend options used in the simulation.
+            """
+            # Check if the lattice sites are in a distance unit
+            assert lattice_sites.dimensionality == ureg.meter.dimensionality
+            # Check if the global rabi frequency is in a frequency unit
+            assert global_rabi_frequency.dimensionality == ureg.hertz.dimensionality
+            # Check if the global phase is dimensionless
+            assert global_phase.dimensionless
+            # Check if the global detuning is in a frequency unit
+            assert global_detuning.dimensionality == ureg.hertz.dimensionality
+            # Check if the local detuning is in a frequency unit
+            assert local_detuning.dimensionality == ureg.hertz.dimensionality
+            # Check if the timegrid is in a time unit
+            assert timegrid.dimensionality == ureg.second.dimensionality
+
+            # Convert any units if your simulator requires it
+            lattice_sites = lattice_sites.to(ureg.meter)
+            global_rabi_frequency = global_rabi_frequency.to(ureg.hertz)
+            global_phase = global_phase.to(ureg.dimensionless)
+            global_detuning = global_detuning.to(ureg.hertz)
+            local_detuning = local_detuning.to(ureg.hertz)
+            timegrid = timegrid.to(ureg.second)
+
+            # Example of running the simulation with mock data
+            state_populations = [0.7, 0.3]  # Mock result for demonstration
+            return {
+                "state_populations": state_populations,
+                "backend_options": self.backend_options,
+            }
+
+        def get_backend_information(self) -> dict:
+            """
+            Retrieve information about the custom backend.
+
+            Returns
+            -------
+            dict
+                Dictionary containing metadata about the backend.
+            """
+            return {
+                "name": self.name,
+                "custom_parameter": self.custom_parameter,
+            }
+
+    class CustomProvider(PasquansProvider):
+        """Custom provider for managing and providing custom simulators."""
+
+        def _get_simulators(self) -> List[SimulatorBackend]:
+            """
+            Return a list of available simulators provided by this provider.
+
+            Returns
+            -------
+            list[SimulatorBackend]
+                A list of simulator classes available through this provider.
+            """
+            return [CustomSimulator]  # Register the CustomSimulator here
+
+    # Example usage with the CustomProvider and CustomSimulator
+    result = simulate(
+        lattice_sites=np.array([(0.0, 0.0, 0.0), (1.0, 1.0, 1.0)]) * Q_("micrometer"),
+        global_rabi_frequency=np.array([1.0, 1.0]) * Q_("MHz"),
+        global_phase=np.array([0.0, 0.0]) * Q_("rad"),
+        global_detuning=np.array([0.0, 0.0]) * Q_("MHz"),
+        local_detuning=np.array([0.0, 0.0]) * Q_("MHz"),
+        init_state=[0.0, 0.0],
+        timegrid=[0.0, 1.0] * Q_("microsecond"),
+        backend="custom_simulator",
+        backend_options={},
+        provider=CustomProvider(),
+    )
+
+    # Access simulation results
+    populations = result["state_populations"]
+    print("Simulation Results:", populations)

--- a/tests/test_simulate_function.py
+++ b/tests/test_simulate_function.py
@@ -30,7 +30,7 @@ def test_simulate_v2():
         global_detuning=np.array([0.0, 0.0]) * Q_("MHz"),
         local_detuning=np.array([0.0, 0.0]) * Q_("MHz"),
         init_state=[0.0, 0.0],
-        timegrid=[0.0, 1.0],
+        timegrid=[0.0, 1.0] * Q_("microsecond"),
         backend="mock_simulator_v2",
         backend_options={},
         provider=MockProvider(),

--- a/tests/test_simulate_function.py
+++ b/tests/test_simulate_function.py
@@ -1,5 +1,7 @@
 from qruise.pasquans_interface import simulate
 from qruise.pasquans_interface import MockProvider
+from qruise.pasquans_interface import Q_
+import numpy as np
 
 
 def test_simulate():
@@ -18,3 +20,22 @@ def test_simulate():
     assert result["state_populations"] == [0.5, 0.5]
     assert result["backend_options"] == {}
     assert "error" not in result
+
+
+def test_simulate_v2():
+    result = simulate(
+        lattice_sites=np.array([(0.0, 0.0, 0.0), (1.0, 1.0, 1.0)]) * Q_("micrometer"),
+        global_rabi_frequency=np.array([1.0, 1.0]) * Q_("MHz"),
+        global_phase=np.array([0.0, 0.0]) * Q_("rad"),
+        global_detuning=np.array([0.0, 0.0]) * Q_("MHz"),
+        local_detuning=np.array([0.0, 0.0]) * Q_("MHz"),
+        init_state=[0.0, 0.0],
+        timegrid=[0.0, 1.0],
+        backend="mock_simulator_v2",
+        backend_options={},
+        provider=MockProvider(),
+    )
+    assert "error" not in result
+
+    assert result["state_populations"] == [0.5, 0.5]
+    assert result["backend_options"] == {}


### PR DESCRIPTION
## What
Add pint units support to the interface.

## Why
Allow compatibility among different simulator backends.

## How
It is possible to pass to the simulate function Pint quantities 
```
result = simulate(
    lattice_sites=np.array([(0.0, 0.0), (1.0, 1.0)]) * Q_("micrometer"),
    global_rabi_frequency=np.array([1.0, 1.0]) * Q_("MHz"),
    global_phase=np.array([0.0, 0.0]) * Q_("rad"),
    global_detuning=np.array([0.0, 0.0]) * Q_("MHz"),
    local_detuning=np.array([0.0, 0.0]) * Q_("MHz"),
    init_state=[1.0, 0.0],
    timegrid=np.array([0.0, 1.0]) * Q_("microsecond"),
    backend="mock_simulator_v2",
    backend_options={},
    provider=MockProvider(),
)
```
The simulator class can check the dimensionality and convert to the correct unit used by that simulator.

```
# Check if the lattice sites are in a distance unit
assert lattice_sites.dimensionality == ureg.meter.dimensionality
# Check if the global rabi frequency is in a frequency unit
assert global_rabi_frequency.dimensionality == ureg.hertz.dimensionality
# Check if the global phase is dimensionless
assert global_phase.dimensionless
# Check if the global detuning is in a frequency unit
assert global_detuning.dimensionality == ureg.hertz.dimensionality
# Check if the local detuning is in a frequency unit
assert local_detuning.dimensionality == ureg.hertz.dimensionality
# Check if the timegrid is in a time unit
assert timegrid.dimensionality == ureg.second.dimensionality

# Convert any units if your simulator requires it
lattice_sites = lattice_sites.to(ureg.meter)
global_rabi_frequency = global_rabi_frequency.to(ureg.hertz)
global_phase = global_phase.to(ureg.dimensionless)
global_detuning = global_detuning.to(ureg.hertz)
local_detuning = local_detuning.to(ureg.hertz)
timegrid = timegrid.to(ureg.second)
```

## Checklist

- [x] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [x] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [x] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [x] Docstrings - Docstrings have been provided for functions in the `numpydoc` style
- [x] Documentation - The tutorial style documentation has been updated to explain changes & new features
- [ ] Notebooks - Example notebooks have been updated to incorporate changes and new features
- [ ] Changelog - A short note on this PR has been added to the Upcoming Release section
